### PR TITLE
fix(server): prevent duplicate message delivery to sender

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -269,8 +269,8 @@ io.on('connection', (socket) => {
   });
 
   socket.on('sendMessage', (message) => {
-    // Kirim pesan ke pengirim dan penerima
-    io.to(`user_${message.id_pengirim}`).emit('receiveMessage', message);
+    // Kirim pesan hanya ke penerima untuk menghindari duplikasi
+    // Pengirim sudah mendapat konfirmasi melalui response HTTP
     io.to(`user_${message.id_penerima}`).emit('receiveMessage', message);
   });
 


### PR DESCRIPTION
The sender already receives confirmation via HTTP response, so we only need to send the message to the recipient to avoid duplication.